### PR TITLE
docs: fix api website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ npm i stream-to-it
 
 # API Docs
 
-- <https://github.com.github.io/alanshaw>
+- <https://alanshaw.github.io/stream-to-it>
 
 # License
 


### PR DESCRIPTION
Looks like this was mangled at some point..